### PR TITLE
docs: Add Swagger UI documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This repository provides public access to OpenAPI specifications while keeping t
 - `openapi.json` - Current OpenAPI 3.0 specification
 - Tags correspond to releases in the main `project-beta-api` repository
 
+## Swagger UI
+
+The repository includes a Swagger UI interface for interactive API documentation. Access it by opening `index.html` in a web browser. The UI loads the OpenAPI specification from `openapi.json` and provides an interactive interface for exploring the API endpoints.
+
 ## Usage
 
 Frontend applications and API consumers can fetch the OpenAPI specification directly from this repository:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ This repository provides public access to OpenAPI specifications while keeping t
 
 ## Swagger UI
 
-The repository includes a Swagger UI interface for interactive API documentation. Access it by opening `index.html` in a web browser. The UI loads the OpenAPI specification from `openapi.json` and provides an interactive interface for exploring the API endpoints.
+The repository includes a Swagger UI interface for interactive API documentation:
+
+- **Live Documentation**: https://matchpoint-ai.github.io/project-beta-api-specs/
+- **Local Access**: Open `index.html` in a web browser
+
+The UI loads the OpenAPI specification from `openapi.json` and provides an interactive interface for exploring the API endpoints.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Added a new "Swagger UI" section to the README documenting how to access the interactive API documentation
- Explains that the UI is available via `index.html` and loads the OpenAPI specification from `openapi.json`

## Test plan
- [x] Verify README renders correctly
- [x] Confirm Swagger UI information is accurate

🤖 Generated with [Claude Code](https://claude.ai/code)